### PR TITLE
feat: remove social share buttons on product pages

### DIFF
--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -101,12 +101,4 @@ $(function() {
     }
   });
 
-
-  // Social link popups
-  $('.social-links a').click(function(e) {
-    e.preventDefault();
-    var shareURL = $(this).attr('href');
-    window.open( shareURL, "myWindow", "status = 1, height = 400, width = 600, resizable = 0" )
-  });
-
 });

--- a/source/product.html
+++ b/source/product.html
@@ -94,16 +94,6 @@
       </div>
     {% endif %}
 
-      {% if theme.show_social %}
-        {% capture tweet_string %}{{ product.name }} - {{ store.name }} {{ page.full_url }}{% endcapture %}
-        {% assign tweet_string = tweet_string | url_encode %}
-        <ul class="social-links">
-          <li><a target="_blank" href="https://twitter.com/intent/tweet?text={{ tweet_string }}">Tweet</a></li>
-          <li><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{store.url}}{{product.url}}">Share</a></li>
-          <li><a target="_blank" href="http://pinterest.com/pin/create/button/?url={{store.url}}{{product.url}}&media={{ product.images.first.url }}">Pin It</a></li>
-        </ul>
-      {% endif %}
-
     </div>
 
   </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -152,13 +152,6 @@
       "description": "Displays product images as a slideshow instead of stacked images"
     },
     {
-      "variable": "show_social",
-      "label": "Show social media buttons",
-      "type": "boolean",
-      "default": false,
-      "description": "Adds social media share buttons to product pages"
-    },
-    {
       "variable": "show_view_badges",
       "label": "Show view badges",
       "type": "boolean",

--- a/source/stylesheets/product.css.sass
+++ b/source/stylesheets/product.css.sass
@@ -89,35 +89,6 @@
 .purchase
   margin-top: 30px
 
-.social-links
-  overflow: hidden
-  margin-top: 30px
-  margin-bottom: 15px
-
-.social-links li
-  float: left
-  margin: 0 10px 10px 0
-
-.social-links li a
-  display: block
-  background: $primary-color
-  color: $background-color
-  text-transform: uppercase
-  font-weight: 700
-  font-size: 12px
-  letter-spacing: 0.09em
-  padding: 5px 10px
-  border-radius: 5px
-  -webkit-touch-callout: none
-  -webkit-user-select: none
-  -khtml-user-select: none
-  -moz-user-select: none
-  -ms-user-select: none
-  user-select: none
-
-.social-links li a:hover
-  color: $highlight-color
-
 #instant-checkout-button
   box-sizing: border-box
   margin-top: 12px


### PR DESCRIPTION
Engagement on these types of Share buttons continues to decrease year over year, so the buttons are being removed. Instead, visitors can copy/paste URLs, use browser plugins, or use the native share tools on mobile browsers.