### PR TITLE
chore: add data hook and page type to Layout

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -8,10 +8,10 @@
     {{ head_content }}
   </head>
 
-  <body id="{{ page.permalink }}" class="{{ page.permalink }} {{ page.category }}">
+  <body id="{{ page.permalink }}" class="{{ page.permalink }} {{ page.category }}" data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
 
     <div class="wrapper">
-      <header>
+      <header data-bc-hook="header">
         <div class="inner clear">
           {% if theme.images.logo.url != blank %}
             <a class="logo" href="/" title="Home"></a>
@@ -87,7 +87,7 @@
 
     </div><!-- End wrapper -->
 
-    <footer>
+    <footer data-bc-hook="footer">
       <div class="inner">
         {% if theme.instagram_url != blank
           or theme.tiktok_url != blank

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Snakebite",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "images": [
     {
       "variable": "logo",

--- a/source/stylesheets/layout.css.sass
+++ b/source/stylesheets/layout.css.sass
@@ -671,7 +671,7 @@ footer
   font-size: 12px
   line-height: 1.3em
   color: $background-color
-  height: 120px
+  min-height: 120px
   text-transform: uppercase
   letter-spacing: 0.09em
   font-weight: 700
@@ -854,7 +854,7 @@ footer
 
   /* Footer */
   footer
-    height: 120px
+    min-height: 120px
 
     .inner
       flex-direction: column


### PR DESCRIPTION
Allows for 3rd party apps to target key regions for adding content. In particular, key for omnisend and email partners to be able to insert content above the footer.

1. Adds `data-bc-hook` attribute to header and footer
2. Adds `data-bc-page-type` attribute to the body tag

Note: A much larger change was previously proposed but I've scaled it back to only the above 2 changes foregoing the larger change which is much more complex.

This also adds in a fix for the footer which has a styling of `height: 120px` which causes problems when social icons wrap:

https://github.com/user-attachments/assets/c9cf13dd-acb4-4244-8f95-e97f1042f99d

Changing this to `min-height: 120px` ensures the right padding exists:

https://github.com/user-attachments/assets/574aaf19-c5d3-4486-81e6-2d0135c62ac3


